### PR TITLE
Update TmxColor.cpp

### DIFF
--- a/src/TmxColor.cpp
+++ b/src/TmxColor.cpp
@@ -57,7 +57,7 @@ namespace Tmx
     Color::Color(const std::string& str)
     {
         // We skip the first # character and then read directly the hexadecimal value
-        color = std::strtol((str.c_str() + 1), nullptr, 16);
+        color = std::strtoul((str.c_str() + 1), nullptr, 16);
 
         // If the input has the short format #RRGGBB without alpha channel we set it to 255
         if(str.length() == 7) color |= 0xff000000;


### PR DESCRIPTION
If alpha channel is higher than 127 and lower than 255 , strtol conversion returns wrong color